### PR TITLE
Add grid search for RandomForest

### DIFF
--- a/CSC_Final.txt
+++ b/CSC_Final.txt
@@ -1,0 +1,152 @@
+import pandas as pd
+
+url = "https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data"
+cols = ['age', 'workclass', 'fnlwgt', 'education', 'education-num',
+        'marital-status', 'occupation', 'relationship', 'race', 'sex',
+        'capital-gain', 'capital-loss', 'hours-per-week', 'native-country', 'income']
+
+df = pd.read_csv(url, header=None, names=cols, na_values=' ?', skipinitialspace=True)
+df = df.dropna()
+df['income'] = df['income'].apply(lambda x: 1 if x.strip() == '>50K' else 0)
+
+
+def simplify_education(ed):
+    ed = ed.strip().lower()
+    if ed == "bachelors":
+        return "Bachelors"
+    elif ed == "masters":
+        return "Masters"
+    elif ed == "doctorate":
+        return "Doctorate"
+    elif ed in ["12th", "hs-grad", "some-college", "assoc-acdm", "assoc-voc"]:
+        return "High School Graduate"
+    else:
+        return "High School Dropout"
+
+df['education_simple'] = df['education'].apply(simplify_education)
+
+def simplify_marital_status(m):
+    m = m.strip().lower()
+    if m.startswith("married"):
+        return "Married"
+    elif m == "never-married":
+        return "Single"
+    elif m in ["divorced", "separated"]:
+        return "Divorced"
+    elif m == "widowed":
+        return "Widowed"
+    else:
+        return "Single"  # default to single if unclear
+
+df['marital_simple'] = df['marital-status'].apply(simplify_marital_status)
+
+
+features = [
+    'age', 'education_simple', 'marital_simple', 'occupation', 'race', 'sex'
+]
+df_features = df[features + ['income']].copy()
+
+from sklearn.preprocessing import LabelEncoder
+
+label_encoders = {}
+for col in ['education_simple', 'marital_simple', 'occupation', 'race', 'sex']:
+    le = LabelEncoder()
+    df_features[col] = le.fit_transform(df_features[col])
+    label_encoders[col] = le
+
+
+from sklearn.model_selection import train_test_split, GridSearchCV
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.pipeline import Pipeline
+
+X = df_features[features]
+y = df_features['income']
+
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, random_state=42, stratify=y
+)
+
+# Build pipeline and hyperparameter search
+pipeline = Pipeline([
+    ("clf", RandomForestClassifier(random_state=42, class_weight="balanced"))
+])
+
+param_grid = {
+    "clf__n_estimators": [100, 200],
+    "clf__max_depth": [None, 10, 20],
+    "clf__min_samples_split": [2, 5],
+}
+
+grid = GridSearchCV(pipeline, param_grid, cv=5, n_jobs=-1)
+grid.fit(X_train, y_train)
+print("Best params:", grid.best_params_)
+print("Best CV score:", grid.best_score_)
+
+best_model = grid.best_estimator_
+
+
+from sklearn.metrics import classification_report
+
+y_pred = best_model.predict(X_test)
+print(classification_report(y_test, y_pred, target_names=['<=50K', '>50K']))
+
+
+import gradio as gr
+import numpy as np
+
+def get_options(col):
+    return label_encoders[col].classes_.tolist()
+
+def predict_income(age, education_simple, marital_simple, occupation, race, sex):
+    input_dict = {
+        'age': age,
+        'education_simple': label_encoders['education_simple'].transform([education_simple])[0],
+        'marital_simple': label_encoders['marital_simple'].transform([marital_simple])[0],
+        'occupation': label_encoders['occupation'].transform([occupation])[0],
+        'race': label_encoders['race'].transform([race])[0],
+        'sex': label_encoders['sex'].transform([sex])[0],
+    }
+    X_input = pd.DataFrame([input_dict])
+    proba = best_model.predict_proba(X_input)[0]
+    pred = np.argmax(proba)
+    pct = round(proba[pred] * 100, 2)
+    if pred == 1:
+        return f"There is a {pct}% chance you make more than $50K per year."
+    else:
+        return f"There is a {pct}% chance you make less than $50K per year."
+
+with gr.Blocks() as demo:
+    gr.Markdown("# Income Prediction App")
+    gr.Markdown("Enter your info to predict your income category.")
+
+    age = gr.Number(label="Age", value=30)
+    education_simple = gr.Dropdown(choices=get_options('education_simple'), label="Education")
+    marital_simple = gr.Dropdown(choices=get_options('marital_simple'), label="Marital Status")
+    occupation = gr.Dropdown(choices=get_options('occupation'), label="Occupation")
+    race = gr.Dropdown(choices=get_options('race'), label="Race")
+    sex = gr.Dropdown(choices=get_options('sex'), label="Sex")
+    predict_btn = gr.Button("Predict")
+    output = gr.Textbox(label="Prediction")
+
+    predict_btn.click(
+        fn=predict_income,
+        inputs=[age, education_simple, marital_simple, occupation, race, sex],
+        outputs=output
+    )
+
+demo.launch()
+
+
+import matplotlib.pyplot as plt
+
+importances = best_model.named_steps['clf'].feature_importances_
+feat_names = features
+
+plt.figure(figsize=(21,8))
+plt.bar(feat_names, importances)
+plt.ylabel('Importance Rating') #This shows on a scale of 0.00 to 0.35 how important the rating is in percentage points
+plt.title('Features That are Important')
+plt.xticks(rotation=45)
+plt.tight_layout()
+plt.show()
+


### PR DESCRIPTION
## Summary
- introduce GridSearchCV for RandomForestClassifier with a pipeline
- output best parameters and cross-validated score

## Testing
- `python CSC_Final.txt` *(fails: Keyboard interrupt after grid search; see output)*

------
https://chatgpt.com/codex/tasks/task_e_688225ee67b8832fa87051e0c9592090