### PR TITLE
Add fairness constraints to income model

### DIFF
--- a/CSC_Final.txt
+++ b/CSC_Final.txt
@@ -42,14 +42,15 @@ df['marital_simple'] = df['marital-status'].apply(simplify_marital_status)
 
 
 features = [
-    'age', 'education_simple', 'marital_simple', 'occupation', 'race', 'sex'
+    'age', 'education_simple', 'marital_simple', 'occupation'
 ]
-df_features = df[features + ['income']].copy()
+sensitive_feature = 'sex'
+df_features = df[features + [sensitive_feature, 'income']].copy()
 
 from sklearn.preprocessing import LabelEncoder
 
 label_encoders = {}
-for col in ['education_simple', 'marital_simple', 'occupation', 'race', 'sex']:
+for col in ['education_simple', 'marital_simple', 'occupation', sensitive_feature]:
     le = LabelEncoder()
     df_features[col] = le.fit_transform(df_features[col])
     label_encoders[col] = le
@@ -58,12 +59,15 @@ for col in ['education_simple', 'marital_simple', 'occupation', 'race', 'sex']:
 from sklearn.model_selection import train_test_split, GridSearchCV
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.pipeline import Pipeline
+from fairlearn.reductions import ExponentiatedGradient, DemographicParity
+from fairlearn.metrics import MetricFrame, selection_rate
 
 X = df_features[features]
 y = df_features['income']
+X_sensitive = df_features[sensitive_feature]
 
-X_train, X_test, y_train, y_test = train_test_split(
-    X, y, test_size=0.2, random_state=42, stratify=y
+X_train, X_test, y_train, y_test, s_train, s_test = train_test_split(
+    X, y, X_sensitive, test_size=0.2, random_state=42, stratify=y
 )
 
 # Build pipeline and hyperparameter search
@@ -84,11 +88,25 @@ print("Best CV score:", grid.best_score_)
 
 best_model = grid.best_estimator_
 
-
 from sklearn.metrics import classification_report
 
-y_pred = best_model.predict(X_test)
+fair_clf = ExponentiatedGradient(
+    RandomForestClassifier(
+        n_estimators=best_model.named_steps['clf'].n_estimators,
+        max_depth=best_model.named_steps['clf'].max_depth,
+        min_samples_split=best_model.named_steps['clf'].min_samples_split,
+        random_state=42,
+        class_weight="balanced",
+    ),
+    constraints=DemographicParity(),
+)
+
+fair_clf.fit(X_train, y_train, sensitive_features=s_train)
+
+y_pred = fair_clf.predict(X_test)
 print(classification_report(y_test, y_pred, target_names=['<=50K', '>50K']))
+mf = MetricFrame(metrics=selection_rate, y_true=y_test, y_pred=y_pred, sensitive_features=s_test)
+print("Selection rate by group:\n", mf.by_group)
 
 
 import gradio as gr
@@ -97,17 +115,15 @@ import numpy as np
 def get_options(col):
     return label_encoders[col].classes_.tolist()
 
-def predict_income(age, education_simple, marital_simple, occupation, race, sex):
+def predict_income(age, education_simple, marital_simple, occupation):
     input_dict = {
         'age': age,
         'education_simple': label_encoders['education_simple'].transform([education_simple])[0],
         'marital_simple': label_encoders['marital_simple'].transform([marital_simple])[0],
         'occupation': label_encoders['occupation'].transform([occupation])[0],
-        'race': label_encoders['race'].transform([race])[0],
-        'sex': label_encoders['sex'].transform([sex])[0],
     }
     X_input = pd.DataFrame([input_dict])
-    proba = best_model.predict_proba(X_input)[0]
+    proba = fair_clf.predict_proba(X_input)[0]
     pred = np.argmax(proba)
     pct = round(proba[pred] * 100, 2)
     if pred == 1:
@@ -123,18 +139,16 @@ with gr.Blocks() as demo:
     education_simple = gr.Dropdown(choices=get_options('education_simple'), label="Education")
     marital_simple = gr.Dropdown(choices=get_options('marital_simple'), label="Marital Status")
     occupation = gr.Dropdown(choices=get_options('occupation'), label="Occupation")
-    race = gr.Dropdown(choices=get_options('race'), label="Race")
-    sex = gr.Dropdown(choices=get_options('sex'), label="Sex")
     predict_btn = gr.Button("Predict")
     output = gr.Textbox(label="Prediction")
 
     predict_btn.click(
         fn=predict_income,
-        inputs=[age, education_simple, marital_simple, occupation, race, sex],
+        inputs=[age, education_simple, marital_simple, occupation],
         outputs=output
     )
 
-demo.launch()
+demo.launch(share=False, prevent_thread_lock=True)
 
 
 import matplotlib.pyplot as plt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Income Prediction Project
 
-This project uses the UCI Adult dataset to train a Random Forest classifier that predicts whether a person makes over $50K per year. The repository contains:
+This project uses the UCI Adult dataset to train a Random Forest classifier that predicts whether a person makes over $50K per year. To help mitigate bias, the training features exclude sensitive attributes such as race and sex, and fairness constraints are enforced using the `fairlearn` library. The repository contains:
 
 - `CSC_Final.txt` – a Python script that loads the data, simplifies certain categorical features, encodes them, performs a grid search over hyperparameters, and provides an interactive Gradio app for making predictions.
 - `CSC_Final.ipynb` – a companion notebook implementing a similar pipeline using a `ColumnTransformer` and showing feature importance.
@@ -21,7 +21,7 @@ graph TD
 
 ## Usage
 
-1. Install the required Python packages (pandas, scikit‑learn, numpy, gradio, matplotlib).
+1. Install the required Python packages (pandas, scikit‑learn, numpy, gradio, matplotlib, fairlearn).
 2. Run `python CSC_Final.txt` to execute the script and launch the Gradio application.
 3. Alternatively, open `CSC_Final.ipynb` in Jupyter to explore the notebook version.
 


### PR DESCRIPTION
## Summary
- mitigate bias by removing race/sex features from training
- add Fairlearn exponentiated gradient fairness reduction
- update Gradio interface and README

## Testing
- `python -m py_compile CSC_Final.txt`
- `timeout 30 python CSC_Final.txt` *(fails: timed out before finishing training)*

------
https://chatgpt.com/codex/tasks/task_e_68822c384a98832f988793194dd1ef05